### PR TITLE
Add .gitignore for Python artifacts and DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+# Environment files
+.env
+
+# Database files
+ri_experiment.db


### PR DESCRIPTION
## Summary
- avoid committing Python caches, build artifacts and virtual environments
- ignore database file `ri_experiment.db`
- ignore `.env` settings file

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685b1a2c671083258b3f15102613628f